### PR TITLE
Fixes #56 update release documentation

### DIFF
--- a/src/ontology/README.md
+++ b/src/ontology/README.md
@@ -100,7 +100,7 @@ To make changes to the PHASES, edit `phases-edit.owl`. **DO NOT** edit the `phas
    Then commit the release:
 
    ```copy these files to the root
-   git commit -m "release for YYYY-MM-DD"
+   git commit -am "release for YYYY-MM-DD"
    ```
 
 4. Push the Release Branch


### PR DESCRIPTION
Updates release instructions to use git commit "-am" so all modified tracked files are included in commits.